### PR TITLE
Add missing word in exception message

### DIFF
--- a/lib/ReferenceFinderExtension.php
+++ b/lib/ReferenceFinderExtension.php
@@ -49,7 +49,7 @@ class ReferenceFinderExtension implements Extension
             }
 
             throw new RuntimeException(sprintf(
-                'At least one implementation must be registered with tag "%s"',
+                'At least one implementation finder must be registered with tag "%s"',
                 self::TAG_IMPLEMENTATION_FINDER
             ));
         });


### PR DESCRIPTION
This error message is really confusing since it is
produced when looking for implementations.